### PR TITLE
优化Example_33_ProjectWindowItemOnGUI中使用快捷键Alt时显示文件名后缀样式

### DIFF
--- a/Assets/Editor/Examples/Example_33_ProjectWindowItemOnGUI/Editor/ShowFileExtensions.cs
+++ b/Assets/Editor/Examples/Example_33_ProjectWindowItemOnGUI/Editor/ShowFileExtensions.cs
@@ -47,9 +47,18 @@ public static class ShowFileExtensions
                 else
                 {
                     // we overpaint the filename here, does look a bit dirty and might need adjustment of the offset
-                    var labelRect = rect.Translate(new Vector2(19.5f, 0f));
-                    var fileName = Path.GetFileName(assetPath);
-                    GUI.Label(labelRect, fileName);
+                    var font = GUI.skin.font;
+                    var fonSize = GUI.skin.label.fontSize;
+                    var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(assetPath);
+                    var width = 18.0f;
+                    foreach (var t in fileNameWithoutExtension)
+                    {
+                        font.GetCharacterInfo(t, out var characterInfo, fonSize);
+                        width += characterInfo.advance;
+                    }
+
+                    var labelRect = rect.Translate(new Vector2(width, -1.5f));
+                    GUI.Label(labelRect, Path.GetExtension(assetPath));
                 }
             }
 


### PR DESCRIPTION


**优化后截图**
![image](https://user-images.githubusercontent.com/18352884/117260076-436a8280-ae81-11eb-8039-f997a57a6d7f.png)


**原截图**
![image](https://user-images.githubusercontent.com/18352884/117260192-672dc880-ae81-11eb-8542-756e4a660f47.png)